### PR TITLE
#152919321 Reseting Cache Once a Muscle is Deleted

### DIFF
--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -18,6 +18,7 @@ import logging
 
 from django.contrib.auth.mixins import (
     PermissionRequiredMixin, LoginRequiredMixin)
+from django.core.cache import cache
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
@@ -29,7 +30,7 @@ from django.views.generic import (
     UpdateView
 )
 
-from wger.exercises.models import Muscle
+from wger.exercises.models import Muscle, Exercise
 from wger.utils.generic_views import (
     WgerFormMixin,
     WgerDeleteMixin
@@ -148,4 +149,5 @@ class MuscleDeleteView(
         context['form_action'] = reverse(
             'exercise:muscle:delete', kwargs={
                 'pk': self.kwargs['pk']})
+        cache.clear()
         return context

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -30,7 +30,7 @@ from django.views.generic import (
     UpdateView
 )
 
-from wger.exercises.models import Muscle, Exercise
+from wger.exercises.models import Muscle
 from wger.utils.generic_views import (
     WgerFormMixin,
     WgerDeleteMixin


### PR DESCRIPTION
#### What does this PR do?
Resets cache once a muscle is deleted.

#### Description of Task to be completed?
Once a muscle is deleted on the list, it should not appear on a description of any of the created exercises.

#### How should this be manually tested?
Run python ./manage.py runserver to visit the wger application.
While on the dashboard, click on the Exercises drop down arrow on the top navigation bar then Add Exercise.
Create a new exercise and add any particular muscle in your description.
Head back to the Exercises drop down arrow and head to Muscles. Delete the same muscle added to the exercise you just created.
If you head back to your exercise the muscle will no longer be in the description.

#### What are the relevant pivotal tracker stories?
Pivotal Tracker story ID: 152919321