### PR TITLE
[#153468949] Allow an admin remove a user from a gym

### DIFF
--- a/wger/core/models.py
+++ b/wger/core/models.py
@@ -22,6 +22,7 @@ import fitbit
 from fitbit.exceptions import HTTPUnauthorized
 
 from django.db import models
+from django.db.models import Q
 from django.db.models import IntegerField
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -366,6 +367,22 @@ class UserProfile(models.Model):
         except WeightEntry.DoesNotExist:
             weight = 0
         return weight
+
+    @property
+    def gyms(self):
+        '''
+        Returns the gyms that this particular user belongs to
+        '''
+        try:
+            gyms = Gym.objects\
+                .filter(
+                    Q(gymuserconfig__user_id=self.user) |
+                    Q(gymadminconfig__user_id=self.user))\
+                .values('id', 'name').distinct()
+        except Exception:
+            gyms = []
+
+        return gyms
 
     @property
     def address(self):

--- a/wger/core/templates/user/delete_from_gym.html
+++ b/wger/core/templates/user/delete_from_gym.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% load i18n staticfiles wger_extras %}
+
+{% block title %}{% trans "Delete User From Gym" %} : {{ gym.name }} {% endblock %}
+
+
+{% block header %}
+{% endblock %}
+
+{% block content %}
+
+<form action="{{form_action}}"
+      method="post"
+      class="form-horizontal"
+      role="form">
+    <div class="panel panel-danger">
+        <div class="panel-heading">
+            <h4 class="panel-title">{% trans "Are you sure?" %}</h4>
+        </div>
+        <div class="panel-body">
+            {% with username=user_delete|format_username %}
+            <p>
+                {% blocktrans %}
+                    This action will delete the user account "{{username}}" from {{ gym.name }}.
+                {% endblocktrans %}
+            </p>
+            {% endwith %}
+
+            {% csrf_token %}
+
+            {% render_form_submit 'Delete from gym' 'danger' %}
+        </div>
+    </div>
+</form>
+
+{% endblock %}
+
+
+{% block sidebar %}
+{% endblock %}

--- a/wger/core/templates/user/overview.html
+++ b/wger/core/templates/user/overview.html
@@ -206,6 +206,14 @@
             <a href="{% url 'core:user:edit' current_user.pk %}" class="wger-modal-dialog">{% trans "Edit"%}</a>
         </li>
         <li class="divider"></li>
+
+        <!-- in the actions menu, add items that allow an admin remove a user from a gym -->
+        <li class="dropdown-header">{% trans "Remove From Gym"%}</li>
+        {% for gym in current_user.userprofile.gyms %}
+            <li><a class="dropdown-item wger-modal-dialog" href="{% url 'core:user:delete-user-from-gym' current_user.pk gym.id %}">{{ gym.name }}</a></li>
+        {% endfor %}
+
+        <li class="divider"></li>
         <li>
             {% if current_user.is_active %}
                 <a href="{% url 'core:user:deactivate' current_user.pk %}" >{% trans "Deactivate user"%}</a>

--- a/wger/core/urls.py
+++ b/wger/core/urls.py
@@ -67,6 +67,12 @@ patterns_user = [
     url(r'^(?P<user_pk>\d+)/delete$',
         user.delete,
         name='delete'),
+
+    # url used to remove a user from a gym
+    url(r'^(?P<user_pk>\d+)/delete/gym/(?P<gym_pk>\d+)$',
+        user.delete_from_gym,
+        name='delete-user-from-gym'),
+
     url(r'^(?P<user_pk>\d+)/trainer-login$',
         user.trainer_login,
         name='trainer-login'),

--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -169,8 +169,8 @@ def delete_from_gym(request, user_pk=None, gym_pk=None):
         # users.
         if not request.user.has_perm('gym.manage_gyms') \
                 and (not request.user.has_perm('gym.manage_gym')
-                    #  or request.user.userprofile.gym_id !=
-                    #  user.userprofile.gym_id
+                     or request.user.userprofile.gym_id !=
+                     user.userprofile.gym_id
                      or user.has_perm('gym.manage_gym')
                      or user.has_perm('gym.gym_trainer')
                      or user.has_perm('gym.manage_gyms')):

--- a/wger/gym/managers.py
+++ b/wger/gym/managers.py
@@ -36,7 +36,7 @@ class GymManager(models.Manager):
         perm_gyms = Permission.objects.get(codename='manage_gyms')
         perm_trainer = Permission.objects.get(codename='gym_trainer')
 
-        users = User.objects.filter(userprofile__gym_id=gym_pk)
+        users = User.objects.filter(gymuserconfig__gym_id=gym_pk)
         return users.exclude(Q(groups__permissions=perm_gym) |
                              Q(groups__permissions=perm_gyms) |
                              Q(groups__permissions=perm_trainer)).distinct()
@@ -49,7 +49,7 @@ class GymManager(models.Manager):
         perm_gyms = Permission.objects.get(codename='manage_gyms')
         perm_trainer = Permission.objects.get(codename='gym_trainer')
 
-        users = User.objects.filter(userprofile__gym_id=gym_pk)
+        users = User.objects.filter(gymadminconfig__gym_id=gym_pk)
         return users.filter(Q(groups__permissions=perm_gym) |
                             Q(groups__permissions=perm_gyms) |
                             Q(groups__permissions=perm_trainer)).distinct()

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -48,12 +48,14 @@
                 </td>
                 {% if show_gym %}
                 <td>
-                    {% if current_user.obj.userprofile.gym_id %}
-                    <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-                        {{ current_user.obj.userprofile.gym }}
-                    </a>
+                    {% if current_user.obj.userprofile.gyms %}
+                        {% for gym in current_user.obj.userprofile.gyms %}
+                            <a href="{% url 'gym:gym:user-list' gym.id %}">
+                                {{ gym.name }}
+                            </a>,
+                        {% endfor %}
                     {% else %}
-                    -/-
+                        -/-
                     {% endif %}
                 </td>
                 {% endif %}
@@ -90,13 +92,17 @@
                 </td>
                 {% if show_gym %}
                 <td>
-                    {% if current_user.obj.userprofile.gym_id %}
-                    <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-                        {{ current_user.obj.userprofile.gym }}
-                    </a>
+
+                    {% if current_user.obj.userprofile.gyms %}
+                        {% for gym in current_user.obj.userprofile.gyms %}
+                            <a href="{% url 'gym:gym:user-list' gym.id %}">
+                                {{ gym.name }}
+                            </a>,
+                        {% endfor %}
                     {% else %}
-                    -/-
+                        -/-
                     {% endif %}
+
                 </td>
                 {% endif %}
             </tr>
@@ -133,12 +139,14 @@
                 </td>
                 {% if show_gym %}
                 <td>
-                    {% if current_user.obj.userprofile.gym_id %}
-                    <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-                        {{ current_user.obj.userprofile.gym }}
-                    </a>
+                    {% if current_user.obj.userprofile.gyms %}
+                        {% for gym in current_user.obj.userprofile.gyms %}
+                            <a href="{% url 'gym:gym:user-list' gym.id %}">
+                                {{ gym.name }}
+                            </a>,
+                        {% endfor %}
                     {% else %}
-                    -/-
+                        -/-
                     {% endif %}
                 </td>
                 {% endif %}

--- a/wger/gym/tests/test_export.py
+++ b/wger/gym/tests/test_export.py
@@ -50,7 +50,7 @@ class GymMembersCsvExportTestCase(WorkoutManagerTestCase):
             self.assertEqual(
                 response['Content-Disposition'],
                 'attachment; filename={0}'.format(filename))
-            self.assertGreaterEqual(len(response.content), 854)
+            self.assertGreaterEqual(len(response.content), 1000)
             self.assertLessEqual(len(response.content), 1300)
 
     def test_export_csv_authorized(self):

--- a/wger/gym/tests/test_export.py
+++ b/wger/gym/tests/test_export.py
@@ -50,7 +50,7 @@ class GymMembersCsvExportTestCase(WorkoutManagerTestCase):
             self.assertEqual(
                 response['Content-Disposition'],
                 'attachment; filename={0}'.format(filename))
-            self.assertGreaterEqual(len(response.content), 1000)
+            self.assertGreaterEqual(len(response.content), 854)
             self.assertLessEqual(len(response.content), 1300)
 
     def test_export_csv_authorized(self):


### PR DESCRIPTION
#### What does this PR do?
It gives admin users the ability to remove users from a gym in their capacities as a user, trainer or manager

#### Description of Task to be completed?

#### Any background context you want to provide?
Previously, users who were added to a gym could not be removed from it after being added

#### What are the relevant pivotal tracker stories?
[#153468949](https://www.pivotaltracker.com/story/show/153468949)

#### Screenshots (if appropriate)
When an admin looks at a users profile, under the action dropdown, they have the option of removing that user from a list of gyms

<img width="188" alt="screen shot 2017-12-19 at 16 22 28" src="https://user-images.githubusercontent.com/9318050/34159065-dda98646-e4d8-11e7-93a8-bb3e4a18e761.png">

When a gym is selected, a confirmation modal is displayed

<img width="629" alt="screen shot 2017-12-19 at 16 23 19" src="https://user-images.githubusercontent.com/9318050/34159086-f49ce186-e4d8-11e7-8079-ac9c4186d860.png">

and once the button is hit, if successful, this is the screen as is seen by the user with a flash message

<img width="1440" alt="screen shot 2017-12-19 at 16 24 19" src="https://user-images.githubusercontent.com/9318050/34159119-20d02e3e-e4d9-11e7-9876-070177c83967.png">
